### PR TITLE
Fix Contao 5.3 spam blocking and form retry handling

### DIFF
--- a/src/EventListener/AntiSpamFormListener.php
+++ b/src/EventListener/AntiSpamFormListener.php
@@ -12,7 +12,6 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Form;
 use Contao\FormModel;
 use Contao\System;
-use Contao\Controller;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -134,7 +133,7 @@ class AntiSpamFormListener
             );
 
             if ($blockSpam) {
-                $this->blockSpam($formId);
+                $this->blockSpam($form, $formId);
             }
 
             return;
@@ -161,10 +160,17 @@ class AntiSpamFormListener
             );
 
             if ($blockSpam) {
-                $this->blockSpam($formId);
+                $this->blockSpam($form, $formId);
             }
 
-            $session->remove($sessionKey);
+            if ($blockSpam) {
+                // Neuer Startzeitpunkt für einen erneuten Formularversuch
+                $session->set($sessionKey, time());
+            } else {
+                // Bei nur markiertem Spam wird der Vorgang regulär abgeschlossen
+                $session->remove($sessionKey);
+            }
+
             return;
         }
 
@@ -201,7 +207,7 @@ class AntiSpamFormListener
                     );
 
                     if ($blockSpam) {
-                        $this->blockSpam($formId);
+                        $this->blockSpam($form, $formId);
                     }
 
                     return;
@@ -251,7 +257,7 @@ class AntiSpamFormListener
                         );
 
                         if ($blockSpam) {
-                            $this->blockSpam($formId);
+                            $this->blockSpam($form, $formId);
                         }
 
                         return;
@@ -393,7 +399,7 @@ class AntiSpamFormListener
                     );
 
                     if ($blockSpam) {
-                        $this->blockSpam($formId);
+                        $this->blockSpam($form, $formId);
                     }
 
                     return;
@@ -441,7 +447,7 @@ class AntiSpamFormListener
             );
 
             if ($blockSpam) {
-                $this->blockSpam($formId);
+                $this->blockSpam($form, $formId);
             }
 
             return;
@@ -480,12 +486,22 @@ class AntiSpamFormListener
                     $this->markAsSpam($submittedData, $honeypotField, $spamMarker, $formId);
 
                     if ($blockSpam) {
-                        $this->blockSpam($formId);
+                        $this->blockSpam($form, $formId);
                     } elseif ($debugMode) {
-                        $this->loggingHelper->logInfo('SPAM MARKED: E-Mail will be sent with SPAM marker', __METHOD__);
+                        $this->loggingHelper->logInfo(
+                            'SPAM MARKED: E-Mail will be sent with SPAM marker',
+                            __METHOD__
+                        );
                     }
 
-                    $session->remove($sessionKey);
+                    if ($blockSpam) {
+                        // Neuer Startzeitpunkt für einen erneuten Formularversuch
+                        $session->set($sessionKey, time());
+                    } else {
+                        // Bei nur markiertem Spam wird der Vorgang regulär abgeschlossen
+                        $session->remove($sessionKey);
+                    }
+
                     return;
                 }
             }
@@ -508,10 +524,17 @@ class AntiSpamFormListener
             );
 
             if ($blockSpam) {
-                $this->blockSpam($formId);
+                $this->blockSpam($form, $formId);
             }
 
-            $session->remove($sessionKey);
+            if ($blockSpam) {
+                // Neuer Startzeitpunkt für einen erneuten Formularversuch
+                $session->set($sessionKey, time());
+            } else {
+                // Bei nur markiertem Spam wird der Vorgang regulär abgeschlossen
+                $session->remove($sessionKey);
+            }
+
             return;
         }
 
@@ -532,7 +555,7 @@ class AntiSpamFormListener
             );
 
             if ($blockSpam) {
-                $this->blockSpam($formId);
+                $this->blockSpam($form, $formId);
             }
 
             $session->remove($sessionKey);
@@ -644,21 +667,28 @@ class AntiSpamFormListener
     /**
      * Blockiert SPAM komplett (keine E-Mail)
      */
-    private function blockSpam(int $formId): void
+    private function blockSpam(Form $form, int $formId): void
     {
-        $this->loggingHelper->logError('SPAM BLOCKED: Redirecting to prevent form processing', __METHOD__);
+        $this->loggingHelper->logError(
+            'SPAM BLOCKED: E-Mail will NOT be sent',
+            __METHOD__
+        );
 
-        // Session aufräumen
+        $form->addError(
+            $GLOBALS['TL_LANG']['ERR']['c2nSpamBlocked']
+                ?? 'Your request could not be processed. Please try again later.'
+        );
+
         $request = $this->requestStack->getCurrentRequest();
-        if ($request && $request->hasSession()) {
-            $request->getSession()->remove('c2n_form_timestamp_' . $formId);
-        }
 
-        // Natives header() + exit() – kann NICHT von try-catch gefangen werden.
-        // Controller::redirect() wirft intern eine Exception die in Contao 5
-        // von umgebenden try-catch Blöcken abgefangen werden kann.
-        $uri = $request ? $request->getUri() : '/';
-        header('Location: ' . $uri, true, 302);
-        exit();
+        if ($request && $request->hasSession()) {
+            $session = $request->getSession();
+
+            // Neuer Startzeitpunkt für einen erneuten Versuch
+            $session->set(
+                'c2n_form_timestamp_' . $formId,
+                time()
+            );
+        }
     }
 }

--- a/src/EventListener/FormLoadListener.php
+++ b/src/EventListener/FormLoadListener.php
@@ -36,13 +36,7 @@ class FormLoadListener
      */
     public function __invoke(array $fields, string $formId, Form $form): array
     {
-        // FIX: In Contao 5.3 kann formId "auto_form_1" sein (String mit Prefix)
-        // Wir müssen die Nummer extrahieren!
-        if (strpos($formId, 'auto_form_') === 0) {
-            $formIdInt = (int)str_replace('auto_form_', '', $formId);
-        } else {
-            $formIdInt = (int)$formId;
-        }
+        $formIdInt = (int) $form->id;
 
         // Formular-Konfiguration laden
         $formModel = FormModel::findByPk($formIdInt);

--- a/src/Resources/contao/languages/de/default.php
+++ b/src/Resources/contao/languages/de/default.php
@@ -1,0 +1,4 @@
+<?php
+
+$GLOBALS['TL_LANG']['ERR']['c2nSpamBlocked'] =
+    'Ihre Anfrage konnte nicht verarbeitet werden. Bitte versuchen Sie es später erneut.';

--- a/src/Resources/contao/languages/en/default.php
+++ b/src/Resources/contao/languages/en/default.php
@@ -1,0 +1,4 @@
+<?php
+
+$GLOBALS['TL_LANG']['ERR']['c2nSpamBlocked'] =
+    'Your request could not be processed. Please try again later.';

--- a/src/Resources/contao/languages/nl/default.php
+++ b/src/Resources/contao/languages/nl/default.php
@@ -1,0 +1,4 @@
+<?php
+
+$GLOBALS['TL_LANG']['ERR']['c2nSpamBlocked'] =
+    'Uw aanvraag kon niet worden verwerkt. Probeer het later opnieuw.';


### PR DESCRIPTION
## Summary

This PR fixes several issues in the spam blocking flow under Contao 5.3.

### Changes

- use the actual `Form` instance when blocking spam
- stop form processing via `Form::addError()` instead of redirect/header/exit handling
- preserve a fresh form timestamp after blocked submissions so legitimate retries work
- resolve the numeric form ID directly from `$form->id`
- add translated spam-block messages for DE, EN and NL

### Background

The previous blocking approach could still allow mail processing or leave the form in a state where subsequent legitimate submissions were rejected due to the session timestamp handling.

The changes were tested in Contao 5.3 with:

- normal form submissions
- blocked spam submissions
- retry after a blocked submission
- Contao standard mail
- Notification Center mail
- DE / NL frontend language switching

The implementation was also tested against the current `1.1.0` codebase.